### PR TITLE
Enable core rule set in modsecurity

### DIFF
--- a/root/default/nginx/conf.d/modsecurity.conf
+++ b/root/default/nginx/conf.d/modsecurity.conf
@@ -27,6 +27,9 @@ modsecurity_rules '
     # Load OWASP core rule set main config
     Include /config/nginx/modsec.d/crs-setup.conf
 
+    # Load OWASP core rule set
+    Include /config/nginx/modsec.d/rules/*.conf
+
     # Custom Modsecurity AV scanner rule
     SecRule FILES_TMPNAMES "@inspectFile /config/nginx/modsec.d/tools/av-scanning/runav.pl" \
         "id:400001, \


### PR DESCRIPTION
This effectively enable the core rules for `modsecurity`.