### PR TITLE
Fix crowdsec ghost request

### DIFF
--- a/root/etc/cont-init.d/20-nginx-config
+++ b/root/etc/cont-init.d/20-nginx-config
@@ -38,6 +38,12 @@ fi
 # Make av scanner script executable
 chmod +x /config/nginx/modsec.d/tools/av-scanning/runav.pl
 
+if [ -z ${CROWDSEC_API_TOKEN+x} ] && [ -z ${CROWDSEC_API_TOKEN_FILE+x} ]; then
+	chmod u-r /config/nginx/conf.d/lua.conf
+else
+  chmod u+r /config/nginx/conf.d/lua.conf
+fi
+
 # Download/update bad bot, blocking and serval other lists
 chmod +x /etc/scripts.d/refresh-agent.sh
 chmod +x /etc/scripts.d/refresh-agent-weekly.sh


### PR DESCRIPTION
When the `crowdsec` capability is not used the `nginx` error log get spammed with the following line:
```log
2022/01/04 16:19:17 [error] 8066#8066: *17 [lua] CrowdSec.lua:121: allowIp(): [Crowdsec] Http error connection refused while talking to LAPI (http://127.0.0.1:8080/v1/decisions?ip=192.168.224.1), client: 192.168.224.1, server: api.example.com, request: "GET /v1/11?asdf=../../../etc/passwd HTTP/2.0", host: "api.example.com"
```
The error description indicate that the system is producing an additional request towards the `crowdsec` system for `ip` validation purposes. The described behavior is adding an additional overhead to the system and produces a performance impact. Al the above are relevant if the `crowdsec` capability is not used. Closing, its worth to be noted that this is relevant for all site blocks.